### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-language: python
-python: 2.7
 sudo: required
 addons:
   apt:


### PR DESCRIPTION
try removing the python language - it causes my ansible to be started in a virtualenv that can't get to the python-apt binding.