### PR TITLE
rename galaxy role to ansible_rclone

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,4 +1,4 @@
-- src: stefangweichinger.rclone
+- src: stefangweichinger.ansible_rclone
   version: v1.42
 - src: robertdebock.mitogen
   version: 1.1.1


### PR DESCRIPTION
stefangweichinger.rclone no longer exists in galaxy, is now stefangweichinger.ansible_rclone, discovered by failing dependabot/security builds